### PR TITLE
Travis tests for Windows and fix for failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - '6'
   - '8'
   - node
+os:
+  - windows
+  - osx
+  - linux

--- a/test.js
+++ b/test.js
@@ -170,6 +170,28 @@ tape('write/read big chunks', function (t) {
   }
 })
 
+tape('destroy', function (t) {
+  var name = gen()
+  var file = raf(name)
+
+  file.write(0, Buffer.from('hi'), function (err) {
+    t.error(err, 'no error')
+    file.read(0, 2, function (err, buf) {
+      t.error(err, 'no error')
+      t.same(buf, Buffer.from('hi'))
+      file.destroy(ondestroy)
+    })
+  })
+
+  function ondestroy (err) {
+    t.error(err, 'no error')
+    fs.stat(name, function (err) {
+      t.same(err && err.code, 'ENOENT', 'should be removed')
+      t.end()
+    })
+  }
+})
+
 tape('rmdir option', function (t) {
   var name = path.join('rmdir', ++i + '', 'folder', 'test.txt')
   var file = raf(name, {rmdir: true, directory: tmp})


### PR DESCRIPTION
This PR adds cross-platform travis tests for osx and Windows to check for cross-platform filesystem peculiarities.

On Windows there is a breaking test for trying to create raf for a directory. On Linux and Mac `fs.open()` on a directory returns an error, but on Windows it returns a file descriptor (https://nodejs.org/api/fs.html#fs_file_system_flags).

This PR fixes the breaking test by adding an additional check on open to check a `fd` is not a directory.