### PR TITLE
Fix path resolution issue on Windows platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var RandomAccess = require('random-access-storage')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 var path = require('path')
+var unixify = require('unixify')
 var constants = fs.constants || require('constants')
 
 var READONLY = constants.O_RDONLY
@@ -15,7 +16,7 @@ function RandomAccessFile (filename, opts) {
   RandomAccess.call(this)
 
   if (!opts) opts = {}
-  if (opts.directory) filename = path.join(opts.directory, path.resolve('/', filename))
+  if (opts.directory) filename = path.join(opts.directory, unixify(path.resolve('/', filename)))
 
   this.directory = opts.directory || null
   this.filename = filename

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "browser": "./browser.js",
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "random-access-storage": "^1.1.1"
+    "random-access-storage": "^1.1.1",
+    "unixify": "^1.0.0"
   },
   "devDependencies": {
     "standard": "^10.0.3",

--- a/test.js
+++ b/test.js
@@ -318,7 +318,7 @@ tape('cannot escape directory', function (t) {
 })
 
 tape('directory filename resolves correctly', function (t) {
-  var name = gen()
+  var name = 'test.txt'
   var file = raf(name, {writable: true, directory: tmp})
   t.same(file.filename, path.join(tmp, name))
   t.end()

--- a/test.js
+++ b/test.js
@@ -317,6 +317,13 @@ tape('cannot escape directory', function (t) {
   })
 })
 
+tape('directory filename resolves correctly', function (t) {
+  var name = gen()
+  var file = raf(name, {writable: true, directory: tmp})
+  t.same(file.filename, path.join(tmp, name))
+  t.end()
+})
+
 function gen () {
   return path.join(tmp, ++i + '.txt')
 }


### PR DESCRIPTION
v2.1.1 (3156e2fcd48186fc26d108d9e8eb15a2313d9da3) introduced a Windows specific issue with path resolution. On Windows `path.resolve('/')` produces `C:\` so the following occurs:
```
var directory = `C:\tmp\random-folder`
var filename = `test.txt`
filename = path.join(directory, path.resolve('/', filename))
// filename = `C:\tmp\random-folder\C:\test.txt`
```
Added test, should also fix the failing rmdir tests (Windows of course).