### PR TITLE
remove browser field that breaks webpacked electron packages

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,3 +1,0 @@
-module.exports = function () {
-  throw new Error('random-access-file is not supported in the browser')
-}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "random-access-file",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Continuous reading or writing to a file using random offsets and lengths",
   "main": "index.js",
   "scripts": {
     "test": "standard && tape test.js"
   },
-  "browser": "./browser.js",
   "dependencies": {
     "mkdirp": "^0.5.1",
     "random-access-storage": "^1.1.1"


### PR DESCRIPTION
Webpack sets the "browser" field in all Electron targets (not unreasonably), which prevents random-access-file from loading in any Electron applications. I couldn't find any kind of workaround so here's a PR to remove the feature of blocking access to r-a-f in a browser.