### PR TITLE
BREAKING: Drop Node 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ os:
   - osx
   - windows
 node_js:
-  - '8'
   - '10'
   - node

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var inherits = require('util').inherits
 var RandomAccess = require('random-access-storage')
 var fs = require('fs')
-var mkdirp = require('mkdirp')
 var path = require('path')
 var constants = fs.constants || require('constants')
 
@@ -35,7 +34,7 @@ inherits(RandomAccessFile, RandomAccess)
 RandomAccessFile.prototype._open = function (req) {
   var self = this
 
-  mkdirp(path.dirname(this.filename), ondir)
+  fs.mkdir(path.dirname(this.filename), { recursive: true }, ondir)
 
   function ondir (err) {
     if (err) return req.callback(err)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "browser": "./browser.js",
   "dependencies": {
-    "mkdirp": "^0.5.1",
     "random-access-storage": "^1.1.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -3,13 +3,12 @@ var tape = require('tape')
 var os = require('os')
 var path = require('path')
 var fs = require('fs')
-var mkdirp = require('mkdirp')
 var isWin = process.platform === 'win32'
 
 var tmp = path.join(os.tmpdir(), 'random-access-file-' + process.pid + '-' + Date.now())
 var i = 0
 
-mkdirp.sync(tmp)
+fs.mkdirSync(tmp, { recursive: true })
 
 tape('write and read', function (t) {
   var file = raf(gen())


### PR DESCRIPTION
Use the new fs.mkdir {recursive: true} option instead of the mkdirp dependency.

It might be too early to merge this, since Node 8 is still supported until the end of the 2019. But just sending this PR so we can merge it at some point in the future.

For: https://github.com/brave/brave-browser/issues/5490