### PR TITLE
Sparse support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var mkdirp = require('mkdirp-classic')
 var path = require('path')
 var constants = fs.constants || require('constants')
+var fswin = require('fswin')
 
 var READONLY = constants.O_RDONLY
 var READWRITE = constants.O_RDWR | constants.O_CREAT
@@ -39,6 +40,10 @@ RandomAccessFile.prototype._open = function (req) {
 
   function ondir (err) {
     if (err) return req.callback(err)
+    // on Windows, set the file as sparse
+    if (fswin) {
+      fswin.ntfs.setSparseSync(self.filename, true)
+    }
     open(self, READWRITE, req)
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "browser": "./browser.js",
   "dependencies": {
+    "fswin": "^3.21.107",
     "mkdirp-classic": "^0.5.2",
     "random-access-storage": "^1.1.1"
   },

--- a/test.js
+++ b/test.js
@@ -344,7 +344,12 @@ tape('sparse functionality on windows', function (t) {
             t.equal(sparseStat.blksize, regularStat.blksize, 'block size sanity check')
             t.comment('sparse blks: ' + sparseStat.blocks +
                      ' regular blks: ' + regularStat.blocks)
-            t.ok(sparseStat.blocks < regularStat.blocks, 'sparse file should use far less blocks')
+            if (sparseStat.blocks === undefined || regularStat.blocks === undefined) {
+              // https://github.com/nodejs/node/pull/26056
+              t.comment('can\'t make file comparisions in this node version')
+            } else {
+              t.ok(sparseStat.blocks < regularStat.blocks / 2, 'sparse file should use far less blocks')
+            }
             raf(sparseFile).destroy(() => {
               raf(regularFile).destroy(() => t.end())
             })


### PR DESCRIPTION
Utilizing the `fswin` package, upon opening a file, set the sparse flag in Windows, this operation takes 0.1ms on my computer so I believe it's safe to do on every file open.

I also included some tests that only run in Windows. I might have let it get out of hand with all the callbacks, but the callback style of this project triggered my nostalgia for a time before promises. Feel free to not include them, or let me know if you'd prefer me to remake them (or anything else) using modern technology or a different methodology.

This closes #23 and will be a pivotal step towards closing [hypercore#281](https://github.com/hypercore-protocol/hypercore/issues/281)