### PR TITLE
Unlink error paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ module.exports = class RandomAccessFile extends RandomAccessStorage {
       // if the file isn't there, its already unlinked, ignore
       if (err && err.code === 'ENOENT') err = null
 
-      if (!self._rmdir || !root || dir === root) return req.callback(err)
+      if (err || !self._rmdir || !root || dir === root) return req.callback(err)
       fs.rmdir(dir, onrmdir)
     }
 

--- a/index.js
+++ b/index.js
@@ -235,7 +235,12 @@ module.exports = class RandomAccessFile extends RandomAccessStorage {
 
     function onrmdir (err) {
       dir = path.join(dir, '..')
-      if (err || dir === root) return req.callback(null)
+
+      const isAlreadyUnlinked = err && err.code === 'ENOENT'
+      const isNotEmpty = err && err.code === 'ENOTEMPTY'
+      if (isAlreadyUnlinked || isNotEmpty || dir === root) return req.callback(null)
+
+      if (err) return req.callback(err)
       fs.rmdir(dir, onrmdir)
     }
   }


### PR DESCRIPTION
- No longer still tries to remove the parent directories if an error occurred while removing the file (previous behaviour swallowed that error)
- More precise error check while removing the parent directories: now throws the error if it is not of an expected type