### PR TITLE
Use "unlink" instead of "destroy" in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Stat the storage. Should return an object with useful information about the unde
 
 Close the underlying file descriptor.
 
-#### `file.destroy([callback])`
+#### `file.unlink([callback])`
 
 Unlink the underlying file.
 


### PR DESCRIPTION
["destroy" was renamed to "unlink"][0] in the code. This updates the docs to reflect that change.

[0]: https://github.com/random-access-storage/random-access-storage/commit/bcbe0d6191ceb44e830c1ebfefd8c42d8237e5d2